### PR TITLE
23 string listener not return the actual data

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,6 +11,6 @@ jobs:
       - name: Checking out
         uses: actions/checkout@v2.3.4
       - name: Building and testing
-        uses: ichiro-its/ros2-ci@v0.4.1
+        uses: ichiro-its/ros2-ci@v1.0.0
         with:
           ros2-distro: foxy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,8 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
 
   ament_add_gtest(${PROJECT_NAME}_tests
-    "test/base_broadcast_listen_test.cpp"
+    "test/base_broadcaster_and_listener_test.cpp"
+    "test/string_broadcaster_and_listener_test.cpp"
     "test/udp_socket_test.cpp")
 
   target_link_libraries(${PROJECT_NAME}_tests ${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
+install(DIRECTORY "include" DESTINATION ".")
+
 add_library(${PROJECT_NAME}
   "src/broadcaster/base_broadcaster.cpp"
   "src/broadcaster/string_broadcaster.cpp"
@@ -27,62 +29,39 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 
-install(DIRECTORY "include" DESTINATION ".")
-
 install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION "lib"
   LIBRARY DESTINATION "lib"
   RUNTIME DESTINATION "bin")
 
-add_executable(hello_world_broadcaster "examples/hello_world_broadcaster.cpp")
-target_include_directories(hello_world_broadcaster PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
-target_link_libraries(hello_world_broadcaster ${PROJECT_NAME})
+set(EXECUTABLES
+  "examples/hello_world_broadcaster.cpp"
+  "examples/hello_world_listener.cpp"
+  "examples/position_broadcaster.cpp"
+  "examples/position_listener.cpp"
+  "examples/fruits_broadcaster.cpp"
+  "examples/fruits_listener.cpp")
 
-add_executable(hello_world_listener "examples/hello_world_listener.cpp")
-target_include_directories(hello_world_listener PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
-target_link_libraries(hello_world_listener ${PROJECT_NAME})
+foreach(EXECUTABLE ${EXECUTABLES})
+  get_filename_component(TARGET ${EXECUTABLE} NAME_WE)
 
-add_executable(position_broadcaster "examples/position_broadcaster.cpp")
-target_include_directories(position_broadcaster PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
-target_link_libraries(position_broadcaster ${PROJECT_NAME})
+  add_executable(${TARGET} ${EXECUTABLE})
+  target_link_libraries(${TARGET} ${PROJECT_NAME})
 
-add_executable(position_listener "examples/position_listener.cpp")
-target_include_directories(position_listener PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
-target_link_libraries(position_listener ${PROJECT_NAME})
-
-add_executable(fruits_broadcaster "examples/fruits_broadcaster.cpp")
-target_include_directories(fruits_broadcaster PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
-target_link_libraries(fruits_broadcaster ${PROJECT_NAME})
-
-add_executable(fruits_listener "examples/fruits_listener.cpp")
-target_include_directories(fruits_listener PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
-target_link_libraries(fruits_listener ${PROJECT_NAME})
-
-install(
-  TARGETS
-    hello_world_broadcaster
-    hello_world_listener
-    position_broadcaster
-    position_listener
-    fruits_broadcaster
-    fruits_listener
-  DESTINATION lib/${PROJECT_NAME})
+  install(TARGETS ${TARGET}
+    DESTINATION "lib/${PROJECT_NAME}")
+endforeach()
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
+
+  ament_add_gtest(${PROJECT_NAME}_tests
+    "test/udp_socket_test.cpp")
+
+  target_link_libraries(${PROJECT_NAME}_tests ${PROJECT_NAME})
+
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
 
   ament_add_gtest(${PROJECT_NAME}_tests
+    "test/base_broadcast_listen_test.cpp"
     "test/udp_socket_test.cpp")
 
   target_link_libraries(${PROJECT_NAME}_tests ${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(${PROJECT_NAME}_tests
     "test/base_broadcaster_and_listener_test.cpp"
+    "test/broadcaster_and_listener_test.cpp"
     "test/string_broadcaster_and_listener_test.cpp"
     "test/udp_socket_test.cpp")
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Musen (無線)
 
 [![latest version](https://img.shields.io/github/v/release/ichiro-its/musen)](https://github.com/ichiro-its/musen/releases/)
-[![commit activity](https://img.shields.io/github/commit-activity/m/ichiro-its/musen)](https://github.com/ichiro-its/musen/commits/master)
+[![commits since latest version](https://img.shields.io/github/commits-since/ichiro-its/musen/latest)](https://github.com/ichiro-its/musen/commits/master)
+[![milestone](https://img.shields.io/github/milestones/progress/ichiro-its/musen/1?label=milestone)](https://github.com/ichiro-its/musen/milestone/2)
 [![license](https://img.shields.io/github/license/ichiro-its/musen)](./LICENSE)
 [![build and test status](https://img.shields.io/github/workflow/status/ichiro-its/musen/Build%20and%20Test?label=build%20and%20test)](https://github.com/ichiro-its/musen/actions)
 
@@ -15,9 +16,19 @@ In this package, the broadcast communication will be handled by a Broadcaster ob
 - Specify the port number and target hosts to be used.
 - Message serialization support for string, list of string, and struct data.
 
+## Requirement
+
+- This package requires [ROS 2 Foxy Fitzroy](https://docs.ros.org/en/foxy/).
+
 ## Installation
 
-- Install ROS 2 Foxy as in [this guide](https://docs.ros.org/en/foxy/Installation.html).
+### Binary Packages
+
+- See [releases](https://github.com/ichiro-its/musen/releases) for the latest version of this package.
+- Alternatively, this package is available on [ICHIRO ITS Repository](https://repository.ichiro-its.org/) as a `ros-foxy-musen` package.
+
+### Build From Source
+
 - Install colcon as in [this guide](https://colcon.readthedocs.io/en/released/user/installation.html).
 - Build the project and source the result.
   ```bash
@@ -32,4 +43,4 @@ See [examples](./examples) for information on how to use this package.
 
 ## License
 
-This project is maintained by [ICHIRO ITS](https://github.com/ichiro-its) and licensed under the [MIT License](./LICENSE).
+This project is maintained by [ICHIRO ITS](https://ichiro-its.org/) and licensed under the [MIT License](./LICENSE).

--- a/include/musen/broadcaster/base_broadcaster.hpp
+++ b/include/musen/broadcaster/base_broadcaster.hpp
@@ -21,8 +21,10 @@
 #ifndef MUSEN__BROADCASTER__BASE_BROADCASTER_HPP_
 #define MUSEN__BROADCASTER__BASE_BROADCASTER_HPP_
 
+#include <arpa/inet.h>
+
 #include <string>
-#include <vector>
+#include <list>
 
 #include "../udp_socket.hpp"
 
@@ -32,18 +34,22 @@ namespace musen
 class BaseBroadcaster : public UdpSocket
 {
 public:
-  explicit BaseBroadcaster(int port);
+  explicit BaseBroadcaster(const int & port);
 
-  int send(const void * data, int length);
+  int send(const void * data, const int & length);
 
-  void enable_broadcast(bool enable);
-  void add_target_host(std::string host);
+  void enable_broadcast(const bool & enable);
+  void add_target_host(const std::string & host);
 
-  int get_port();
+  const int & get_port() const;
 
 protected:
+  std::list<struct sockaddr_in> get_recipent_sas() const;
+  std::list<struct sockaddr_in> get_recipent_sas_from_broadcast_ifas() const;
+  std::list<struct sockaddr_in> get_recipent_sas_from_target_hosts() const;
+
   bool broadcast;
-  std::vector<std::string> target_hosts;
+  std::list<std::string> target_hosts;
 
   int port;
 };

--- a/include/musen/broadcaster/broadcaster.hpp
+++ b/include/musen/broadcaster/broadcaster.hpp
@@ -30,12 +30,12 @@ template<typename T>
 class Broadcaster : public BaseBroadcaster
 {
 public:
-  explicit Broadcaster(int port)
+  explicit Broadcaster(const int & port)
   : BaseBroadcaster(port)
   {
   }
 
-  int send(const T data)
+  int send(const T & data)
   {
     return BaseBroadcaster::send(&data, sizeof(data));
   }

--- a/include/musen/broadcaster/string_broadcaster.hpp
+++ b/include/musen/broadcaster/string_broadcaster.hpp
@@ -32,10 +32,10 @@ namespace musen
 class StringBroadcaster : public BaseBroadcaster
 {
 public:
-  explicit StringBroadcaster(int port);
+  explicit StringBroadcaster(const int & port);
 
-  int send(std::string data);
-  int send(std::vector<std::string> data, std::string delimiter = ",");
+  int send(const std::string & message);
+  int send(const std::vector<std::string> & messages, const std::string & delimiter = ",");
 };
 
 }  // namespace musen

--- a/include/musen/listener/base_listener.hpp
+++ b/include/musen/listener/base_listener.hpp
@@ -29,13 +29,13 @@ namespace musen
 class BaseListener : public UdpSocket
 {
 public:
-  explicit BaseListener(int port);
+  explicit BaseListener(const int & port);
 
   bool connect() override;
 
-  int receive(void * buffer, int length);
+  int receive(void * buffer, const int & length);
 
-  int get_port();
+  const int & get_port() const;
 
 protected:
   int port;

--- a/include/musen/listener/listener.hpp
+++ b/include/musen/listener/listener.hpp
@@ -32,7 +32,7 @@ template<typename T>
 class Listener : public BaseListener
 {
 public:
-  explicit Listener(int port)
+  explicit Listener(const int & port)
   : BaseListener(port)
   {
   }

--- a/include/musen/listener/string_listener.hpp
+++ b/include/musen/listener/string_listener.hpp
@@ -32,10 +32,10 @@ namespace musen
 class StringListener : public BaseListener
 {
 public:
-  explicit StringListener(int port);
+  explicit StringListener(const int & port);
 
-  std::string receive(int length);
-  std::vector<std::string> receive(int length, std::string delimiter);
+  std::string receive(const int & length);
+  std::vector<std::string> receive(const int & length, const std::string & delimiter);
 };
 
 }  // namespace musen

--- a/include/musen/musen.hpp
+++ b/include/musen/musen.hpp
@@ -21,8 +21,10 @@
 #ifndef MUSEN__MUSEN_HPP_
 #define MUSEN__MUSEN_HPP_
 
+#include "./broadcaster/base_broadcaster.hpp"
 #include "./broadcaster/broadcaster.hpp"
 #include "./broadcaster/string_broadcaster.hpp"
+#include "./listener/base_listener.hpp"
 #include "./listener/listener.hpp"
 #include "./listener/string_listener.hpp"
 #include "./udp_socket.hpp"

--- a/include/musen/udp_socket.hpp
+++ b/include/musen/udp_socket.hpp
@@ -33,7 +33,7 @@ public:
   virtual bool connect();
   virtual bool disconnect();
 
-  bool is_connected();
+  bool is_connected() const;
 
 protected:
   int sockfd;

--- a/package.xml
+++ b/package.xml
@@ -4,6 +4,7 @@
   <name>musen</name>
   <version>1.1.0</version>
   <description>A UDP broadcast communication library</description>
+  <url>https://github.com/ichiro-its/musen</url>
   <maintainer email="alfi.maulana.f@gmail.com">Alfi Maulana</maintainer>
   <license>MIT License</license>
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/package.xml
+++ b/package.xml
@@ -4,9 +4,9 @@
   <name>musen</name>
   <version>1.1.0</version>
   <description>A UDP broadcast communication library</description>
-  <url>https://github.com/ichiro-its/musen</url>
   <maintainer email="alfi.maulana.f@gmail.com">Alfi Maulana</maintainer>
   <license>MIT License</license>
+  <url>https://github.com/ichiro-its/musen</url>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -2,11 +2,12 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>musen</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>A UDP broadcast communication library</description>
   <maintainer email="alfi.maulana.f@gmail.com">Alfi Maulana</maintainer>
   <license>MIT License</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <export>

--- a/src/broadcaster/base_broadcaster.cpp
+++ b/src/broadcaster/base_broadcaster.cpp
@@ -20,68 +20,119 @@
 
 #include <musen/broadcaster/base_broadcaster.hpp>
 
-#include <arpa/inet.h>
 #include <ifaddrs.h>
 
 #include <cstring>
+#include <list>
 #include <string>
-#include <vector>
 
 namespace musen
 {
 
-BaseBroadcaster::BaseBroadcaster(int port)
-: UdpSocket(),
+BaseBroadcaster::BaseBroadcaster(const int & port)
+: broadcast(true),
   port(port)
 {
 }
 
-int BaseBroadcaster::send(const void * data, int length)
+int BaseBroadcaster::send(const void * data, const int & length)
 {
   if (!is_connected() || length <= 0) {
     return 0;
   }
 
-  // List of recipent socket address
-  std::vector<struct sockaddr_in> sas;
+  // Get list of recipent socket addresses
+  const auto & sas = get_recipent_sas();
 
-  // Append recpient socket addresses with broadcast address
-  if (broadcast) {
-    // Obtain all interfaces
-    struct ifaddrs * ifas;
-    if (getifaddrs(&ifas) != 0) {
-      return 0;
+  // Sent to each recipent socket addresses
+  int lowest_sent = -1;
+  for (const auto & sa : sas) {
+    int sent = sendto(sockfd, data, length, 0, (struct sockaddr *)&sa, sizeof(sa));
+
+    // If lowest_sent is not yet set (-1) or sent is less than lowest_sent
+    if (lowest_sent < 0 || sent < lowest_sent) {
+      lowest_sent = sent;
     }
-
-    // Repeat for all available interfaces
-    for (auto & ifa = ifas; ifa != nullptr; ifa = ifa->ifa_next) {
-      // Skip if null or if the address family is different
-      if (ifa->ifa_addr == nullptr || ifa->ifa_addr->sa_family != AF_INET) {
-        continue;
-      }
-
-      // Get the broadcast address
-      auto broadaddr = (struct sockaddr_in *)ifa->ifa_broadaddr;
-
-      // Configure the recipent address
-      struct sockaddr_in sa;
-      {
-        memset(reinterpret_cast<void *>(&sa), 0, sizeof(sa));
-
-        sa.sin_family = AF_INET;
-        sa.sin_addr = broadaddr->sin_addr;
-        sa.sin_port = htons(port);
-      }
-
-      sas.push_back(sa);
-    }
-
-    freeifaddrs(ifas);
   }
 
-  // Append recipent socket addresses with target address
-  for (auto & target_host : target_hosts) {
-    // Configure the recipent address
+  // Return the lowest sent size from all addresses
+  return lowest_sent;
+}
+
+void BaseBroadcaster::enable_broadcast(const bool & enable)
+{
+  broadcast = enable;
+}
+
+void BaseBroadcaster::add_target_host(const std::string & target_host)
+{
+  target_hosts.push_back(target_host);
+}
+
+const int & BaseBroadcaster::get_port() const
+{
+  return port;
+}
+
+std::list<struct sockaddr_in> BaseBroadcaster::get_recipent_sas() const
+{
+  std::list<struct sockaddr_in> sas;
+
+  sas.splice(sas.end(), get_recipent_sas_from_broadcast_ifas());
+  sas.splice(sas.end(), get_recipent_sas_from_target_hosts());
+
+  return sas;
+}
+
+std::list<struct sockaddr_in> BaseBroadcaster::get_recipent_sas_from_broadcast_ifas() const
+{
+  std::list<struct sockaddr_in> sas;
+
+  if (!broadcast) {
+    return sas;
+  }
+
+  // Obtain all interfaces
+  struct ifaddrs * ifas;
+  if (getifaddrs(&ifas) != 0) {
+    return sas;
+  }
+
+  // Repeat for all available interfaces
+  for (auto ifa = ifas; ifa != nullptr; ifa = ifa->ifa_next) {
+    // Skip if null or if the address family is different
+    if (ifa->ifa_addr == nullptr || ifa->ifa_addr->sa_family != AF_INET) {
+      continue;
+    }
+
+    // Get the broadcast address
+    const auto & broadaddr = (struct sockaddr_in *)ifa->ifa_broadaddr;
+
+    // Configure the recipent socket address
+    struct sockaddr_in sa;
+    {
+      memset(reinterpret_cast<void *>(&sa), 0, sizeof(sa));
+
+      sa.sin_family = AF_INET;
+      sa.sin_addr = broadaddr->sin_addr;
+      sa.sin_port = htons(port);
+    }
+
+    sas.push_back(sa);
+  }
+
+  freeifaddrs(ifas);
+
+  return sas;
+}
+
+std::list<struct sockaddr_in> BaseBroadcaster::get_recipent_sas_from_target_hosts() const
+{
+  std::list<struct sockaddr_in> sas;
+
+  // Append recipent socket addresses with target hosts
+  for (const auto & target_host : target_hosts) {
+    // Configure the recipent socket address
     struct sockaddr_in sa;
     {
       memset(reinterpret_cast<void *>(&sa), 0, sizeof(sa));
@@ -95,34 +146,7 @@ int BaseBroadcaster::send(const void * data, int length)
     sas.push_back(sa);
   }
 
-  int lowest_sent = -1;
-
-  // Sent to each recipent socket addresses
-  for (auto & sa : sas) {
-    int sent = sendto(sockfd, data, length, 0, (struct sockaddr *)&sa, sizeof(sa));
-
-    // If lowest_sent is not yet set (-1) or sent is less than lowest_sent
-    if (lowest_sent < 0 || sent < lowest_sent) {
-      lowest_sent = sent;
-    }
-  }
-
-  return lowest_sent;
-}
-
-void BaseBroadcaster::enable_broadcast(bool enable)
-{
-  broadcast = enable;
-}
-
-void BaseBroadcaster::add_target_host(std::string target_host)
-{
-  target_hosts.push_back(target_host);
-}
-
-int BaseBroadcaster::get_port()
-{
-  return port;
+  return sas;
 }
 
 }  // namespace musen

--- a/src/broadcaster/base_broadcaster.cpp
+++ b/src/broadcaster/base_broadcaster.cpp
@@ -22,6 +22,7 @@
 
 #include <ifaddrs.h>
 
+#include <algorithm>
 #include <cstring>
 #include <list>
 #include <string>
@@ -56,7 +57,7 @@ int BaseBroadcaster::send(const void * data, const int & length)
   }
 
   // Return the lowest sent size from all addresses
-  return lowest_sent;
+  return std::max(lowest_sent, 0);
 }
 
 void BaseBroadcaster::enable_broadcast(const bool & enable)

--- a/src/broadcaster/string_broadcaster.cpp
+++ b/src/broadcaster/string_broadcaster.cpp
@@ -26,28 +26,34 @@
 namespace musen
 {
 
-StringBroadcaster::StringBroadcaster(int port)
+StringBroadcaster::StringBroadcaster(const int & port)
 : BaseBroadcaster(port)
 {
 }
 
-int StringBroadcaster::send(std::string data)
+int StringBroadcaster::send(const std::string & message)
 {
-  return BaseBroadcaster::send(data.c_str(), data.size());
+  return BaseBroadcaster::send(message.c_str(), message.size());
 }
 
-int StringBroadcaster::send(std::vector<std::string> data, std::string delimiter)
+int StringBroadcaster::send(
+  const std::vector<std::string> & messages, const std::string & delimiter)
 {
-  std::string message = "";
-  for (size_t i = 0; i < data.size(); ++i) {
-    message += data[i];
-    if (i != data.size() - 1) {
-      message += delimiter;
+  // Merge vector of strings using the delimiter
+  std::string merged_message = "";
+  for (size_t i = 0; i < messages.size(); ++i) {
+    merged_message += messages[i];
+    if (i != messages.size() - 1) {
+      merged_message += delimiter;
     }
   }
-  message += '\0';
 
-  return send(message);
+  // Add a string termination if it doesn't contain one
+  if (merged_message[merged_message.size() - 1] != '\0') {
+    merged_message += '\0';
+  }
+
+  return send(merged_message);
 }
 
 }  // namespace musen

--- a/src/listener/base_listener.cpp
+++ b/src/listener/base_listener.cpp
@@ -21,7 +21,8 @@
 #include <musen/listener/base_listener.hpp>
 
 #include <arpa/inet.h>
-#include <string.h>
+
+#include <cstring>
 
 namespace musen
 {

--- a/src/listener/base_listener.cpp
+++ b/src/listener/base_listener.cpp
@@ -22,6 +22,7 @@
 
 #include <arpa/inet.h>
 
+#include <algorithm>
 #include <cstring>
 
 namespace musen
@@ -58,7 +59,7 @@ bool BaseListener::connect()
 
 int BaseListener::receive(void * buffer, const int & length)
 {
-  if (!is_connected()) {
+  if (!is_connected() || length <= 0) {
     return 0;
   }
 
@@ -68,7 +69,7 @@ int BaseListener::receive(void * buffer, const int & length)
   // Receive data
   int received = recvfrom(sockfd, buffer, length, 0, &sa, &sa_len);
 
-  return received;
+  return std::max(received, 0);
 }
 
 const int & BaseListener::get_port() const

--- a/src/listener/base_listener.cpp
+++ b/src/listener/base_listener.cpp
@@ -27,9 +27,8 @@
 namespace musen
 {
 
-BaseListener::BaseListener(int port)
-: UdpSocket(),
-  port(port)
+BaseListener::BaseListener(const int & port)
+: port(port)
 {
 }
 
@@ -57,7 +56,7 @@ bool BaseListener::connect()
   return true;
 }
 
-int BaseListener::receive(void * buffer, int length)
+int BaseListener::receive(void * buffer, const int & length)
 {
   if (!is_connected()) {
     return 0;
@@ -72,7 +71,7 @@ int BaseListener::receive(void * buffer, int length)
   return received;
 }
 
-int BaseListener::get_port()
+const int & BaseListener::get_port() const
 {
   return port;
 }

--- a/src/listener/string_listener.cpp
+++ b/src/listener/string_listener.cpp
@@ -26,41 +26,53 @@
 namespace musen
 {
 
-StringListener::StringListener(int port)
+StringListener::StringListener(const int & port)
 : BaseListener(port)
 {
 }
 
-std::string StringListener::receive(int length)
+std::string StringListener::receive(const int & length)
 {
-  char * buffer = new char[length];
+  std::string message;
+  if (length <= 0) {
+    return message;
+  }
 
-  BaseListener::receive(buffer, length);
+  // Resize message buffer according to the requested size
+  message.resize(length);
 
-  std::string message(buffer);
-  delete[] buffer;
+  int received = BaseListener::receive(&message[0], length);
+
+  // Resize message according to the received bytes
+  message.resize(received);
+
+  // Add a string termination if it doesn't contain one
+  if (message[message.size() - 1] != '\0') {
+    message += '\0';
+  }
 
   return message;
 }
 
-std::vector<std::string> StringListener::receive(int length, std::string delimiter)
+std::vector<std::string> StringListener::receive(const int & length, const std::string & delimiter)
 {
-  std::vector<std::string> message;
+  std::vector<std::string> messages;
 
-  std::string received_message = receive(length);
+  auto received_message = receive(length);
 
+  // Separate the received message by the delimiter
   size_t pos = 0;
   while ((pos = received_message.find(delimiter)) != std::string::npos) {
-    message.push_back(received_message.substr(0, pos));
+    messages.push_back(received_message.substr(0, pos));
     received_message.erase(0, pos + delimiter.length());
   }
 
-  // Insert the remaining token into the vector
+  // Insert the remaining token into vector of strings
   if (received_message.length() > 0) {
-    message.push_back(received_message);
+    messages.push_back(received_message);
   }
 
-  return message;
+  return messages;
 }
 
 }  // namespace musen

--- a/src/udp_socket.cpp
+++ b/src/udp_socket.cpp
@@ -76,7 +76,7 @@ bool UdpSocket::disconnect()
   return true;
 }
 
-bool UdpSocket::is_connected()
+bool UdpSocket::is_connected() const
 {
   return sockfd >= 0;
 }

--- a/test/base_broadcast_listen_test.cpp
+++ b/test/base_broadcast_listen_test.cpp
@@ -1,0 +1,102 @@
+// Copyright (c) 2021 ICHIRO ITS
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+#include <musen/musen.hpp>
+
+TEST(BaseBroadcastListenTest, BroadcastListen) {
+  musen::BaseBroadcaster broadcaster(5000);
+  musen::BaseListener listener(5000);
+
+  // Trying to connect both broadcaster and listener
+  ASSERT_TRUE(broadcaster.connect());
+  ASSERT_TRUE(listener.connect());
+
+  char broadcast_data[6] = {'A', 'B', 'C', 'D', 'E', 'F'};
+  char listen_data[6];
+
+  // Do up to 3 times until the listener received a message
+  int iteration = 0;
+  while (iteration++ < 3) {
+    // Sending data (should sent 4 bytes event if has 6 bytes of data)
+    int sent = broadcaster.send(broadcast_data, 4);
+    ASSERT_EQ(sent, 4);
+
+    // Wait a bit so listener could receive the data
+    usleep(10 * 1000);
+
+    // Receiving data (should received 4 bytes even if requested 6 bytes)
+    int received = listener.receive(listen_data, 6);
+    if (received > 0) {
+      // The received size should equal to sent size
+      ASSERT_EQ(received, sent);
+
+      // The received content should equal to sent content
+      for (int i = 0; i < received; ++i) {
+        ASSERT_EQ(listen_data[i], broadcast_data[i]);
+      }
+
+      return SUCCEED();
+    }
+  }
+
+  FAIL() << "listener did not receive any data";
+}
+
+TEST(BaseBroadcastListenTest, BroadcastNothing) {
+  musen::BaseBroadcaster broadcaster(5000);
+
+  // Disable broadcast so it won't sent to anyone
+  broadcaster.enable_broadcast(false);
+
+  // Trying to connect the broadcaster
+  ASSERT_TRUE(broadcaster.connect());
+
+  char broadcast_data[6] = {'A', 'B', 'C', 'D', 'E', 'F'};
+
+  // Do for 3 times
+  for (int i = 0; i < 3; ++i) {
+    // Should sent nothing
+    int sent = broadcaster.send(broadcast_data, 4);
+    ASSERT_LE(sent, 0);
+
+    // Wait a bit
+    usleep(10 * 1000);
+  }
+}
+
+TEST(BaseBroadcastListenTest, ListenNothing) {
+  musen::BaseListener listener(5000);
+
+  // Trying to connect the listener
+  ASSERT_TRUE(listener.connect());
+
+  char listen_data[6];
+
+  // Do for 3 times
+  for (int i = 0; i < 3; ++i) {
+    // Should received nothing
+    int received = listener.receive(listen_data, 6);
+    ASSERT_LE(received, 0);
+
+    // Wait a bit
+    usleep(10 * 1000);
+  }
+}

--- a/test/base_broadcaster_and_listener_test.cpp
+++ b/test/base_broadcaster_and_listener_test.cpp
@@ -34,7 +34,7 @@ TEST(BaseBroadcasterAndListenerTest, SendAndReceive) {
 
   const auto & broadcast_and_listen =
     [&]() {
-      // Do up to 3 times until the listener received a message
+      // Do up to 3 times until the listener has received the data
       int iteration = 0;
       while (iteration++ < 3) {
         // Sending data (must sent 4 bytes event if has 6 bytes of data)

--- a/test/base_broadcaster_and_listener_test.cpp
+++ b/test/base_broadcaster_and_listener_test.cpp
@@ -21,7 +21,7 @@
 #include <gtest/gtest.h>
 #include <musen/musen.hpp>
 
-TEST(BaseBroadcastListenTest, BroadcastListen) {
+TEST(BaseBroadcasterAndListenerTest, SendAndReceive) {
   musen::BaseBroadcaster broadcaster(5000);
   musen::BaseListener listener(5000);
 
@@ -37,20 +37,20 @@ TEST(BaseBroadcastListenTest, BroadcastListen) {
       // Do up to 3 times until the listener received a message
       int iteration = 0;
       while (iteration++ < 3) {
-        // Sending data (should sent 4 bytes event if has 6 bytes of data)
+        // Sending data (must sent 4 bytes event if has 6 bytes of data)
         int sent = broadcaster.send(broadcast_data, 4);
         ASSERT_EQ(sent, 4);
 
         // Wait a bit so listener could receive the data
         usleep(10 * 1000);
 
-        // Receiving data (should received 4 bytes even if requested 6 bytes)
+        // Receiving data (must received 4 bytes even if requested 6 bytes)
         int received = listener.receive(listen_data, 6);
         if (received > 0) {
-          // The received size should equal to sent size
+          // The received size must equal to sent size
           ASSERT_EQ(received, sent);
 
-          // The received content should equal to sent content
+          // The received content must equal to sent content
           for (int i = 0; i < received; ++i) {
             ASSERT_EQ(listen_data[i], broadcast_data[i]);
           }
@@ -75,7 +75,7 @@ TEST(BaseBroadcastListenTest, BroadcastListen) {
   }
 }
 
-TEST(BaseBroadcastListenTest, BroadcastNothing) {
+TEST(BaseBroadcasterAndListenerTest, SendToNoOne) {
   musen::BaseBroadcaster broadcaster(5000);
 
   // Disable broadcast so it won't sent to anyone
@@ -88,16 +88,16 @@ TEST(BaseBroadcastListenTest, BroadcastNothing) {
 
   // Do for 3 times
   for (int i = 0; i < 3; ++i) {
-    // Should sent nothing
+    // Must sent nothing
     int sent = broadcaster.send(broadcast_data, 4);
-    ASSERT_LE(sent, 0);
+    ASSERT_EQ(sent, 0);
 
     // Wait a bit
     usleep(10 * 1000);
   }
 }
 
-TEST(BaseBroadcastListenTest, ListenNothing) {
+TEST(BaseBroadcasterAndListenerTest, ReceiveNothing) {
   musen::BaseListener listener(5000);
 
   // Trying to connect the listener
@@ -107,9 +107,9 @@ TEST(BaseBroadcastListenTest, ListenNothing) {
 
   // Do for 3 times
   for (int i = 0; i < 3; ++i) {
-    // Should received nothing
+    // Must received nothing
     int received = listener.receive(listen_data, 6);
-    ASSERT_LE(received, 0);
+    ASSERT_EQ(received, 0);
 
     // Wait a bit
     usleep(10 * 1000);

--- a/test/base_broadcaster_and_listener_test.cpp
+++ b/test/base_broadcaster_and_listener_test.cpp
@@ -41,7 +41,7 @@ TEST(BaseBroadcasterAndListenerTest, SendAndReceive) {
         int sent = broadcaster.send(broadcast_data, 4);
         ASSERT_EQ(sent, 4);
 
-        // Wait a bit so listener could receive the data
+        // Wait a bit so the listener could receive the data
         usleep(10 * 1000);
 
         // Receiving data (must received 4 bytes even if requested 6 bytes)

--- a/test/broadcaster_and_listener_test.cpp
+++ b/test/broadcaster_and_listener_test.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 ICHIRO ITS
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+#include <musen/musen.hpp>
+
+struct Foo
+{
+  int a;
+  float b;
+};
+
+TEST(BroadcasterAndListenerTest, SendAndReceive) {
+  musen::Broadcaster<Foo> broadcaster(5000);
+  musen::Listener<Foo> listener(5000);
+
+  // Trying to connect both broadcaster and listener
+  ASSERT_TRUE(broadcaster.connect());
+  ASSERT_TRUE(listener.connect());
+
+  Foo broadcast_data;
+  broadcast_data.a = 32;
+  broadcast_data.b = 0.125;
+
+  // Do up to 3 times until the listener has received the data
+  int iteration = 0;
+  while (iteration++ < 3) {
+    // Sending the data
+    broadcaster.send(broadcast_data);
+
+    // Wait a bit so the listener could receive the data
+    usleep(10 * 1000);
+
+    // Receiving data
+    auto listen_data = listener.receive();
+    if (listen_data != nullptr) {
+      // Compare the received and the sent data
+      ASSERT_EQ(listen_data->a, broadcast_data.a);
+      ASSERT_DOUBLE_EQ(listen_data->b, broadcast_data.b);
+
+      return SUCCEED();
+    }
+  }
+
+  FAIL() << "listener did not receive any data";
+}
+
+TEST(BroadcasterAndListenerTest, ReceiveNothing) {
+  musen::Listener<Foo> listener(5000);
+
+  // Trying to connect the listener
+  ASSERT_TRUE(listener.connect());
+
+  // Do for 3 times
+  for (int i = 0; i < 3; ++i) {
+    // Must received nothing
+    auto listen_data = listener.receive();
+    ASSERT_EQ(listen_data, nullptr);
+
+    // Wait a bit
+    usleep(10 * 1000);
+  }
+}

--- a/test/string_broadcaster_and_listener_test.cpp
+++ b/test/string_broadcaster_and_listener_test.cpp
@@ -34,7 +34,7 @@ TEST(StringBroadcasterAndListenerTest, SendAndReceive) {
 
   std::string broadcast_message = "Hello World!";
 
-  // Do up to 3 times until the listener received a message
+  // Do up to 3 times until the listener has received the message
   int iteration = 0;
   while (iteration++ < 3) {
     // Sending message
@@ -70,7 +70,7 @@ TEST(StringBroadcasterAndListenerTest, SendAndReceiveWithDelimiter) {
     "Hello Mars!"
   };
 
-  // Do up to 3 times until the listener received messages
+  // Do up to 3 times until the listener has received the messages
   int iteration = 0;
   while (iteration++ < 3) {
     // Sending messages with a delimiter

--- a/test/string_broadcaster_and_listener_test.cpp
+++ b/test/string_broadcaster_and_listener_test.cpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2021 ICHIRO ITS
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+#include <musen/musen.hpp>
+
+#include <string>
+
+TEST(StringBroadcasterAndListenerTest, SendAndReceive) {
+  musen::StringBroadcaster broadcaster(5000);
+  musen::StringListener listener(5000);
+
+  // Trying to connect both broadcaster and listener
+  ASSERT_TRUE(broadcaster.connect());
+  ASSERT_TRUE(listener.connect());
+
+  std::string broadcast_data = "Hello World!";
+
+  // Do up to 3 times until the listener received a message
+  int iteration = 0;
+  while (iteration++ < 3) {
+    // Sending string data
+    broadcaster.send(broadcast_data);
+
+    // Wait a bit so listener could receive the data
+    usleep(10 * 1000);
+
+    // Receiving string data
+    const auto & listen_data = listener.receive(32);
+    if (listen_data.size() > 0) {
+      // Compare the received and the sent string
+      ASSERT_STREQ(listen_data.c_str(), broadcast_data.c_str());
+
+      return SUCCEED();
+    }
+  }
+
+  FAIL() << "listener did not receive any data";
+}
+
+TEST(StringBroadcasterAndListenerTest, ReceiveNothing) {
+  musen::StringListener listener(5000);
+
+  // Trying to connect the listener
+  ASSERT_TRUE(listener.connect());
+
+  // Do for 3 times
+  for (int i = 0; i < 3; ++i) {
+    // Must received empty string
+    const auto & data = listener.receive(32);
+    ASSERT_EQ(data.size(), 0u);
+
+    // Wait a bit
+    usleep(10 * 1000);
+  }
+}

--- a/test/udp_socket_test.cpp
+++ b/test/udp_socket_test.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 ICHIRO ITS
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+#include <musen/musen.hpp>
+
+TEST(UdpSocketTest, ConnectDisconnect) {
+  musen::UdpSocket udp_socket;
+
+  // The UDP socket isn't connected yet
+  ASSERT_FALSE(udp_socket.is_connected());
+
+  // Trying to connect the UDP socket
+  ASSERT_TRUE(udp_socket.connect());
+  ASSERT_TRUE(udp_socket.is_connected());
+
+  // Should failed if the UDP socket is already connected
+  ASSERT_FALSE(udp_socket.connect());
+  ASSERT_TRUE(udp_socket.is_connected());
+
+  // Trying to disconnect the UDP socket
+  ASSERT_TRUE(udp_socket.disconnect());
+  ASSERT_FALSE(udp_socket.is_connected());
+
+  // Should failed if the UDP socket is already disconnected
+  ASSERT_FALSE(udp_socket.disconnect());
+  ASSERT_FALSE(udp_socket.is_connected());
+}

--- a/test/udp_socket_test.cpp
+++ b/test/udp_socket_test.cpp
@@ -31,7 +31,7 @@ TEST(UdpSocketTest, ConnectDisconnect) {
   ASSERT_TRUE(udp_socket.connect());
   ASSERT_TRUE(udp_socket.is_connected());
 
-  // Should failed because the UDP socket is already connected
+  // Must be failed because the UDP socket is already connected
   ASSERT_FALSE(udp_socket.connect());
   ASSERT_TRUE(udp_socket.is_connected());
 
@@ -39,7 +39,7 @@ TEST(UdpSocketTest, ConnectDisconnect) {
   ASSERT_TRUE(udp_socket.disconnect());
   ASSERT_FALSE(udp_socket.is_connected());
 
-  // Should failed because the UDP socket is already disconnected
+  // Must be failed because the UDP socket is already disconnected
   ASSERT_FALSE(udp_socket.disconnect());
   ASSERT_FALSE(udp_socket.is_connected());
 }

--- a/test/udp_socket_test.cpp
+++ b/test/udp_socket_test.cpp
@@ -31,7 +31,7 @@ TEST(UdpSocketTest, ConnectDisconnect) {
   ASSERT_TRUE(udp_socket.connect());
   ASSERT_TRUE(udp_socket.is_connected());
 
-  // Should failed if the UDP socket is already connected
+  // Should failed because the UDP socket is already connected
   ASSERT_FALSE(udp_socket.connect());
   ASSERT_TRUE(udp_socket.is_connected());
 
@@ -39,7 +39,7 @@ TEST(UdpSocketTest, ConnectDisconnect) {
   ASSERT_TRUE(udp_socket.disconnect());
   ASSERT_FALSE(udp_socket.is_connected());
 
-  // Should failed if the UDP socket is already disconnected
+  // Should failed because the UDP socket is already disconnected
   ASSERT_FALSE(udp_socket.disconnect());
   ASSERT_FALSE(udp_socket.is_connected());
 }


### PR DESCRIPTION
- Fix listen to empty bug in the `StringListener`, Closes #23.
- Add tests for `UdpSocket`, `Broadcaster`s, and `Listener`s.
- Use constant reference in most functions if possible.
- Separate send process and recipient socket addresses get in the `BaseBroadcaster`.
- Use loop to generate executables in `CMakeLists.txt`
- Update package information and workflows's actions version.