### PR TITLE
Miscellaneous changes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,9 +1,10 @@
 name: Build and Test
 on:
+  workflow_dispatch:
   pull_request:
-    branches: [ master ]
+    branches: [master]
   push:
-    branches: [ master ]
+    branches: [master]
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,5 +12,6 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           path: musen
+
       - name: Build and test workspace
         uses: ichiro-its/ros2-build-and-test-action@main

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,9 +8,9 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checking out
+      - name: Checkout this repository
         uses: actions/checkout@v2.3.4
-      - name: Building and testing
-        uses: ichiro-its/ros2-ci@v1.0.0
         with:
-          ros2-distro: foxy
+          path: musen
+      - name: Build and test workspace
+        uses: ichiro-its/ros2-build-and-test-action@main

--- a/.github/workflows/deploy-debian-nightly.yml
+++ b/.github/workflows/deploy-debian-nightly.yml
@@ -1,7 +1,8 @@
 name: Deploy Debian Nightly
 on:
+  workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [master]
 jobs:
   deploy-debian-nightly:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-debian-nightly.yml
+++ b/.github/workflows/deploy-debian-nightly.yml
@@ -1,9 +1,9 @@
-name: Deploy Debian
+name: Deploy Debian Nightly
 on:
-  pull_request:
+  push:
     branches: [ master ]
 jobs:
-  deploy-debian:
+  deploy-debian-nightly:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
@@ -11,10 +11,12 @@ jobs:
         with:
           path: musen
 
-      - name: Build Debian package
+      - name: Build nightly Debian package
         uses: ichiro-its/ros2-build-debian-action@main
+        with:
+          unique-version: true
 
-      - name: Deploy Debian package to server
+      - name: Deploy nightly Debian package to server
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.SSH_HOST }}
@@ -25,7 +27,7 @@ jobs:
           target: "~/temp/nightly/musen/"
           rm: true
 
-      - name: Prepare Debian package in the server
+      - name: Prepare nightly Debian package in the server
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.SSH_HOST }}

--- a/.github/workflows/deploy-debian-stable.yml
+++ b/.github/workflows/deploy-debian-stable.yml
@@ -1,5 +1,6 @@
 name: Deploy Debian Stable
 on:
+  workflow_dispatch:
   release:
     types: [created]
 jobs:

--- a/.github/workflows/deploy-debian-stable.yml
+++ b/.github/workflows/deploy-debian-stable.yml
@@ -1,0 +1,38 @@
+name: Deploy Debian Stable
+on:
+  release:
+    types: [created]
+jobs:
+  deploy-debian-stable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v2.3.4
+        with:
+          path: musen
+
+      - name: Build stable Debian package
+        uses: ichiro-its/ros2-build-debian-action@main
+
+      - name: Deploy stable Debian package to server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASS }}
+          source: "package/*.deb"
+          target: "~/temp/stable/musen/"
+          rm: true
+
+      - name: Prepare stable Debian package in the server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASS }}
+          script: |
+            cd ~/repository/debian
+            reprepro includedeb stable ~/temp/stable/musen/package/*.deb
+            rm -rf ~/temp/stable/musen/

--- a/.github/workflows/deploy-debian.yml
+++ b/.github/workflows/deploy-debian.yml
@@ -1,0 +1,38 @@
+name: Deploy Debian
+on:
+  pull_request:
+    branches: [ master ]
+jobs:
+  deploy-debian:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v2.3.4
+        with:
+          path: musen
+
+      - name: Build Debian package
+        uses: ichiro-its/ros2-build-debian-action@main
+
+      - name: Deploy Debian package to server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASS }}
+          source: "package/*.deb"
+          target: "~/temp/nightly/musen/"
+          rm: true
+
+      - name: Prepare Debian package in the server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASS }}
+          script: |
+            cd ~/repository/debian
+            reprepro includedeb nightly ~/temp/nightly/musen/package/*.deb
+            rm -rf ~/temp/nightly/musen/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In this package, the broadcast communication will be handled by a Broadcaster ob
 ### Binary Packages
 
 - See [releases](https://github.com/ichiro-its/musen/releases) for the latest version of this package.
-- Alternatively, this package also available on [ICHIRO ITS Repository](https://repository.ichiro-its.org/) as a `ros-foxy-musen` package.
+- Alternatively, this package also available on [ICHIRO ITS Repository](https://repository.ichiro-its.org/) as `ros-foxy-musen` package.
 
 ### Build From Source
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 [![latest version](https://img.shields.io/github/v/release/ichiro-its/musen)](https://github.com/ichiro-its/musen/releases/)
 [![commits since latest version](https://img.shields.io/github/commits-since/ichiro-its/musen/latest)](https://github.com/ichiro-its/musen/commits/master)
-[![milestone](https://img.shields.io/github/milestones/progress/ichiro-its/musen/1?label=milestone)](https://github.com/ichiro-its/musen/milestone/2)
 [![license](https://img.shields.io/github/license/ichiro-its/musen)](./LICENSE)
-[![build and test status](https://img.shields.io/github/workflow/status/ichiro-its/musen/Build%20and%20Test?label=build%20and%20test)](https://github.com/ichiro-its/musen/actions)
+[![test status](https://img.shields.io/github/workflow/status/ichiro-its/musen/Build%20and%20Test?label=test)](https://github.com/ichiro-its/musen/actions)
+[![deploy stable status](https://img.shields.io/github/workflow/status/ichiro-its/musen/Deploy%20Debian%20Stable?label=deploy%20stable)](https://repository.ichiro-its.org/)
+[![deploy nightly status](https://img.shields.io/github/workflow/status/ichiro-its/musen/Deploy%20Debian%20Nightly?label=deploy%20nightly)](https://repository.ichiro-its.org/)
 
 Musen (無線, wireless) is a [ROS 2](https://docs.ros.org/en/foxy/index.html) package that provides a [UDP](https://en.wikipedia.org/wiki/User_Datagram_Protocol) broadcast communication library for a ROS 2 project.
 This package is written in C++ and currently only works on Linux based operating system.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In this package, the broadcast communication will be handled by a Broadcaster ob
 ### Binary Packages
 
 - See [releases](https://github.com/ichiro-its/musen/releases) for the latest version of this package.
-- Alternatively, this package is available on [ICHIRO ITS Repository](https://repository.ichiro-its.org/) as a `ros-foxy-musen` package.
+- Alternatively, this package also available on [ICHIRO ITS Repository](https://repository.ichiro-its.org/) as a `ros-foxy-musen` package.
 
 ### Build From Source
 

--- a/include/musen/broadcaster/base_broadcaster.hpp
+++ b/include/musen/broadcaster/base_broadcaster.hpp
@@ -23,23 +23,30 @@
 
 #include <arpa/inet.h>
 
-#include <string>
 #include <list>
+#include <memory>
+#include <string>
 
 #include "../udp_socket.hpp"
 
 namespace musen
 {
 
-class BaseBroadcaster : public UdpSocket
+class BaseBroadcaster
 {
 public:
-  explicit BaseBroadcaster(const int & port);
+  explicit BaseBroadcaster(
+    const int & port, std::shared_ptr<UdpSocket> udp_socket = std::make_shared<UdpSocket>());
 
-  int send(const void * data, const int & length);
+  bool connect();
+  bool disconnect();
+
+  int send(const char * data, const int & length);
 
   void enable_broadcast(const bool & enable);
   void add_target_host(const std::string & host);
+
+  std::shared_ptr<UdpSocket> get_udp_socket() const;
 
   const int & get_port() const;
 
@@ -47,6 +54,8 @@ protected:
   std::list<struct sockaddr_in> get_recipent_sas() const;
   std::list<struct sockaddr_in> get_recipent_sas_from_broadcast_ifas() const;
   std::list<struct sockaddr_in> get_recipent_sas_from_target_hosts() const;
+
+  std::shared_ptr<UdpSocket> udp_socket;
 
   bool broadcast;
   std::list<std::string> target_hosts;

--- a/include/musen/broadcaster/base_broadcaster.hpp
+++ b/include/musen/broadcaster/base_broadcaster.hpp
@@ -51,9 +51,9 @@ public:
   const int & get_port() const;
 
 protected:
-  std::list<struct sockaddr_in> get_recipent_sas() const;
-  std::list<struct sockaddr_in> get_recipent_sas_from_broadcast_ifas() const;
-  std::list<struct sockaddr_in> get_recipent_sas_from_target_hosts() const;
+  std::list<struct sockaddr_in> obtain_recipent_sas() const;
+  std::list<struct sockaddr_in> obtain_recipent_sas_from_broadcast_ifas() const;
+  std::list<struct sockaddr_in> obtain_recipent_sas_from_target_hosts() const;
 
   std::shared_ptr<UdpSocket> udp_socket;
 
@@ -61,6 +61,8 @@ protected:
   std::list<std::string> target_hosts;
 
   int port;
+
+  std::list<struct sockaddr_in> recipent_sas;
 };
 
 }  // namespace musen

--- a/include/musen/broadcaster/broadcaster.hpp
+++ b/include/musen/broadcaster/broadcaster.hpp
@@ -21,6 +21,8 @@
 #ifndef MUSEN__BROADCASTER__BROADCASTER_HPP_
 #define MUSEN__BROADCASTER__BROADCASTER_HPP_
 
+#include <memory>
+
 #include "./base_broadcaster.hpp"
 
 namespace musen
@@ -30,14 +32,15 @@ template<typename T>
 class Broadcaster : public BaseBroadcaster
 {
 public:
-  explicit Broadcaster(const int & port)
-  : BaseBroadcaster(port)
+  explicit Broadcaster(
+    const int & port, std::shared_ptr<UdpSocket> udp_socket = std::make_shared<UdpSocket>())
+  : BaseBroadcaster(port, udp_socket)
   {
   }
 
   int send(const T & data)
   {
-    return BaseBroadcaster::send(&data, sizeof(data));
+    return BaseBroadcaster::send((const char *)&data, sizeof(data));
   }
 };
 

--- a/include/musen/broadcaster/string_broadcaster.hpp
+++ b/include/musen/broadcaster/string_broadcaster.hpp
@@ -21,6 +21,7 @@
 #ifndef MUSEN__BROADCASTER__STRING_BROADCASTER_HPP_
 #define MUSEN__BROADCASTER__STRING_BROADCASTER_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -32,7 +33,8 @@ namespace musen
 class StringBroadcaster : public BaseBroadcaster
 {
 public:
-  explicit StringBroadcaster(const int & port);
+  explicit StringBroadcaster(
+    const int & port, std::shared_ptr<UdpSocket> udp_socket = std::make_shared<UdpSocket>());
 
   int send(const std::string & message);
   int send(const std::vector<std::string> & messages, const std::string & delimiter = ",");

--- a/include/musen/listener/base_listener.hpp
+++ b/include/musen/listener/base_listener.hpp
@@ -21,6 +21,8 @@
 #ifndef MUSEN__LISTENER__BASE_LISTENER_HPP_
 #define MUSEN__LISTENER__BASE_LISTENER_HPP_
 
+#include <memory>
+
 #include "../udp_socket.hpp"
 
 namespace musen
@@ -29,15 +31,21 @@ namespace musen
 class BaseListener : public UdpSocket
 {
 public:
-  explicit BaseListener(const int & port);
+  explicit BaseListener(
+    const int & port, std::shared_ptr<UdpSocket> udp_socket = std::make_shared<UdpSocket>());
 
-  bool connect() override;
+  bool connect();
+  bool disconnect();
 
   int receive(void * buffer, const int & length);
+
+  std::shared_ptr<UdpSocket> get_udp_socket() const;
 
   const int & get_port() const;
 
 protected:
+  std::shared_ptr<UdpSocket> udp_socket;
+
   int port;
 };
 

--- a/include/musen/listener/listener.hpp
+++ b/include/musen/listener/listener.hpp
@@ -32,8 +32,9 @@ template<typename T>
 class Listener : public BaseListener
 {
 public:
-  explicit Listener(const int & port)
-  : BaseListener(port)
+  explicit Listener(
+    const int & port, std::shared_ptr<UdpSocket> udp_socket = std::make_shared<UdpSocket>())
+  : BaseListener(port, udp_socket)
   {
   }
 

--- a/include/musen/listener/string_listener.hpp
+++ b/include/musen/listener/string_listener.hpp
@@ -21,6 +21,7 @@
 #ifndef MUSEN__LISTENER__STRING_LISTENER_HPP_
 #define MUSEN__LISTENER__STRING_LISTENER_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -32,7 +33,8 @@ namespace musen
 class StringListener : public BaseListener
 {
 public:
-  explicit StringListener(const int & port);
+  explicit StringListener(
+    const int & port, std::shared_ptr<UdpSocket> udp_socket = std::make_shared<UdpSocket>());
 
   std::string receive(const int & length);
   std::vector<std::string> receive(const int & length, const std::string & delimiter);

--- a/include/musen/udp_socket.hpp
+++ b/include/musen/udp_socket.hpp
@@ -33,6 +33,8 @@ public:
   virtual bool connect();
   virtual bool disconnect();
 
+  const int & get_sockfd() const;
+
   bool is_connected() const;
 
 protected:

--- a/src/broadcaster/string_broadcaster.cpp
+++ b/src/broadcaster/string_broadcaster.cpp
@@ -20,14 +20,15 @@
 
 #include <musen/broadcaster/string_broadcaster.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace musen
 {
 
-StringBroadcaster::StringBroadcaster(const int & port)
-: BaseBroadcaster(port)
+StringBroadcaster::StringBroadcaster(const int & port, std::shared_ptr<UdpSocket> udp_socket)
+: BaseBroadcaster(port, udp_socket)
 {
 }
 

--- a/src/listener/string_listener.cpp
+++ b/src/listener/string_listener.cpp
@@ -20,14 +20,15 @@
 
 #include <musen/listener/string_listener.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace musen
 {
 
-StringListener::StringListener(const int & port)
-: BaseListener(port)
+StringListener::StringListener(const int & port, std::shared_ptr<UdpSocket> udp_socket)
+: BaseListener(port, udp_socket)
 {
 }
 

--- a/src/udp_socket.cpp
+++ b/src/udp_socket.cpp
@@ -46,19 +46,19 @@ bool UdpSocket::connect()
 
   // Create a new socket
   sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-  if (sockfd < 0) {
+  if (get_sockfd() < 0) {
     return false;
   }
 
   // Enable broadcast
   int opt = 1;
   setsockopt(
-    sockfd, SOL_SOCKET, SO_BROADCAST, reinterpret_cast<void *>(&opt),
+    get_sockfd(), SOL_SOCKET, SO_BROADCAST, reinterpret_cast<void *>(&opt),
     sizeof(opt));
 
   // Enable non-blocking
-  int flags = fcntl(sockfd, F_GETFL, 0);
-  fcntl(sockfd, F_SETFL, flags | O_NONBLOCK);
+  int flags = fcntl(get_sockfd(), F_GETFL, 0);
+  fcntl(get_sockfd(), F_SETFL, flags | O_NONBLOCK);
 
   return true;
 }
@@ -76,9 +76,14 @@ bool UdpSocket::disconnect()
   return true;
 }
 
+const int & UdpSocket::get_sockfd() const
+{
+  return sockfd;
+}
+
 bool UdpSocket::is_connected() const
 {
-  return sockfd >= 0;
+  return get_sockfd() >= 0;
 }
 
 }  // namespace musen


### PR DESCRIPTION
- Use `UdpSocket` as a member variables instead of as a inheritance parent.
- Cache recipent socket addresses by obtaining it outside the `send()` function.
- Modify `build-and-test` workflow to use [ROS 2 build and test workspace action](https://github.com/ichiro-its/ros2-build-and-test-action).
- Add `deploy-debian-nightly` and `deploy-debian-stable` workflows.
- Update badges in the `README.md`.