### PR TITLE
Add Dependabot Configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: chore


### PR DESCRIPTION
This pull request simply adds a new Dependabot configuration that checks for new updates of GitHub Actions Dependencies. It closes #48.