### PR TITLE
Use Deploy GitHub Pages Site Action

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -12,6 +12,15 @@ on:
 jobs:
   deploy-documentation:
     runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-pages.outputs.page_url }}
+    concurrency:
+      group: pages
+      cancel-in-progress: true
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v4.1.2
@@ -34,8 +43,11 @@ jobs:
         working-directory: build
         run: make doc
 
-      - name: Deploy documentation
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+      - name: Upload Documentation
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
-          branch: gh-pages
-          folder: musen/doc
+          path: musen/doc
+
+      - name: Deploy Pages
+        id: deploy-pages
+        uses: actions/deploy-pages@v4.0.4


### PR DESCRIPTION
This pull request resolves #52 by replacing the previous deployment method with the [Deploy GitHub Pages Site](https://github.com/marketplace/actions/deploy-github-pages-site) action.