### PR TITLE
Bump Copyright Year to 2024

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 ICHIRO ITS
+# Copyright (c) 2021-2024 ICHIRO ITS
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 ICHIRO ITS
+# Copyright (c) 2021-2024 ICHIRO ITS
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 ICHIRO ITS
+# Copyright (c) 2021-2024 ICHIRO ITS
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 ICHIRO ITS
+# Copyright (c) 2021-2024 ICHIRO ITS
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 ICHIRO ITS
+# Copyright (c) 2021-2024 ICHIRO ITS
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 ICHIRO ITS
+Copyright (c) 2021-2024 ICHIRO ITS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -70,4 +70,6 @@ You can read the full API documentation in the generated `doc` directory (see [t
 
 ## License
 
-This project is maintained by [ICHIRO ITS](https://ichiro-its.org/) and licensed under the [MIT License](https://github.com/ichiro-its/musen/blob/master/LICENSE).
+This project is licensed under the terms of the [MIT License](https://github.com/ichiro-its/musen/blob/master/LICENSE).
+
+Copyright © 2021-2024 [ICHIRO ITS](https://ichiro.its.ac.id/)

--- a/cmake/doc.cmake
+++ b/cmake/doc.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 ICHIRO ITS
+# Copyright (c) 2021-2024 ICHIRO ITS
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/cmake/lint.cmake
+++ b/cmake/lint.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 ICHIRO ITS
+# Copyright (c) 2021-2024 ICHIRO ITS
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/examples/fruits_udp/fruits_broadcaster.cpp
+++ b/examples/fruits_udp/fruits_broadcaster.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/examples/fruits_udp/fruits_listener.cpp
+++ b/examples/fruits_udp/fruits_listener.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/examples/hello_world_udp/hello_world_broadcaster.cpp
+++ b/examples/hello_world_udp/hello_world_broadcaster.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/examples/hello_world_udp/hello_world_listener.cpp
+++ b/examples/hello_world_udp/hello_world_listener.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/examples/position_tcp/position_client.cpp
+++ b/examples/position_tcp/position_client.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/examples/position_tcp/position_server.cpp
+++ b/examples/position_tcp/position_server.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/examples/position_udp/position_broadcaster.cpp
+++ b/examples/position_udp/position_broadcaster.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/examples/position_udp/position_listener.cpp
+++ b/examples/position_udp/position_listener.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/include/musen/address.hpp
+++ b/include/musen/address.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/include/musen/musen.hpp
+++ b/include/musen/musen.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/include/musen/receiver.hpp
+++ b/include/musen/receiver.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/include/musen/receiver.tpp
+++ b/include/musen/receiver.tpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/include/musen/sender.hpp
+++ b/include/musen/sender.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/include/musen/sender.tpp
+++ b/include/musen/sender.tpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/include/musen/socket.hpp
+++ b/include/musen/socket.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/include/musen/socket.tpp
+++ b/include/musen/socket.tpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/include/musen/tcp/client.hpp
+++ b/include/musen/tcp/client.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/include/musen/tcp/server.hpp
+++ b/include/musen/tcp/server.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/include/musen/tcp/session.hpp
+++ b/include/musen/tcp/session.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/include/musen/udp/broadcaster.hpp
+++ b/include/musen/udp/broadcaster.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/include/musen/udp/listener.hpp
+++ b/include/musen/udp/listener.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/src/receiver.cpp
+++ b/src/receiver.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/src/tcp/client.cpp
+++ b/src/tcp/client.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/src/tcp/server.cpp
+++ b/src/tcp/server.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/src/tcp/session.cpp
+++ b/src/tcp/session.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/src/udp/broadcaster.cpp
+++ b/src/udp/broadcaster.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/src/udp/listener.cpp
+++ b/src/udp/listener.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 ICHIRO ITS
+# Copyright (c) 2021-2024 ICHIRO ITS
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/test/gtest/src/address_test.cpp
+++ b/test/gtest/src/address_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/gtest/src/broadcast_and_listen_test.cpp
+++ b/test/gtest/src/broadcast_and_listen_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/gtest/src/send_and_receive/mocks/mock_receiver.cpp
+++ b/test/gtest/src/send_and_receive/mocks/mock_receiver.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/gtest/src/send_and_receive/mocks/mock_receiver.hpp
+++ b/test/gtest/src/send_and_receive/mocks/mock_receiver.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/gtest/src/send_and_receive/mocks/mock_sender.cpp
+++ b/test/gtest/src/send_and_receive/mocks/mock_sender.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/gtest/src/send_and_receive/mocks/mock_sender.hpp
+++ b/test/gtest/src/send_and_receive/mocks/mock_sender.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/gtest/src/send_and_receive/raw_test.cpp
+++ b/test/gtest/src/send_and_receive/raw_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/gtest/src/send_and_receive/string_test.cpp
+++ b/test/gtest/src/send_and_receive/string_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/gtest/src/send_and_receive/strings_test.cpp
+++ b/test/gtest/src/send_and_receive/strings_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/gtest/src/send_and_receive/struct_test.cpp
+++ b/test/gtest/src/send_and_receive/struct_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/gtest/src/server_and_client_test.cpp
+++ b/test/gtest/src/server_and_client_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/gtest/src/socket/connection_test.cpp
+++ b/test/gtest/src/socket/connection_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/gtest/src/socket/creation_test.cpp
+++ b/test/gtest/src/socket/creation_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/gtest/src/socket/manipulation_test.cpp
+++ b/test/gtest/src/socket/manipulation_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ICHIRO ITS
+// Copyright (c) 2021-2024 ICHIRO ITS
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/test/uncrustify/config.cfg
+++ b/test/uncrustify/config.cfg
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 ICHIRO ITS
+# Copyright (c) 2021-2024 ICHIRO ITS
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/test/uncrustify/test.py
+++ b/test/uncrustify/test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 ICHIRO ITS
+# Copyright (c) 2021-2024 ICHIRO ITS
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at


### PR DESCRIPTION
This pull request simply bumps the copyright year in all files to 2024 and updates the license section in the `README.md` file.