### PR TITLE
Remove License Header in All Files

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,9 +1,3 @@
-# Copyright (c) 2021-2024 ICHIRO ITS
-#
-# Use of this source code is governed by an MIT-style
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/MIT.
-
 name: Build and Test
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -1,9 +1,3 @@
-# Copyright (c) 2021-2024 ICHIRO ITS
-#
-# Use of this source code is governed by an MIT-style
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/MIT.
-
 name: Deploy Documentation
 on:
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-# Copyright (c) 2021-2024 ICHIRO ITS
-#
-# Use of this source code is governed by an MIT-style
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/MIT.
-
 .*
 
 !.git*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,3 @@
-# Copyright (c) 2021-2024 ICHIRO ITS
-#
-# Use of this source code is governed by an MIT-style
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/MIT.
-
 cmake_minimum_required(VERSION 3.5)
 
 project(musen)

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,9 +1,3 @@
-# Copyright (c) 2021-2024 ICHIRO ITS
-#
-# Use of this source code is governed by an MIT-style
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/MIT.
-
 PROJECT_NAME           = "Musen"
 PROJECT_NUMBER         = "v1.1.0"
 PROJECT_BRIEF          = "ROS 2 UDP and TCP socket communication library"

--- a/cmake/doc.cmake
+++ b/cmake/doc.cmake
@@ -1,9 +1,3 @@
-# Copyright (c) 2021-2024 ICHIRO ITS
-#
-# Use of this source code is governed by an MIT-style
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/MIT.
-
 add_custom_target(doc
   COMMAND doxygen
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/cmake/lint.cmake
+++ b/cmake/lint.cmake
@@ -1,9 +1,3 @@
-# Copyright (c) 2021-2024 ICHIRO ITS
-#
-# Use of this source code is governed by an MIT-style
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/MIT.
-
 add_custom_target(lint
   COMMAND
     find "examples" "include" "src" "test"

--- a/examples/fruits_udp/fruits_broadcaster.cpp
+++ b/examples/fruits_udp/fruits_broadcaster.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <cstdlib>
 #include <iostream>
 #include <string>

--- a/examples/fruits_udp/fruits_listener.cpp
+++ b/examples/fruits_udp/fruits_listener.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <iostream>
 #include <string>
 #include <thread>

--- a/examples/hello_world_udp/hello_world_broadcaster.cpp
+++ b/examples/hello_world_udp/hello_world_broadcaster.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <iostream>
 #include <string>
 #include <thread>

--- a/examples/hello_world_udp/hello_world_listener.cpp
+++ b/examples/hello_world_udp/hello_world_listener.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <iostream>
 #include <string>
 #include <thread>

--- a/examples/position_tcp/position_client.cpp
+++ b/examples/position_tcp/position_client.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <cstdlib>
 #include <iostream>
 #include <thread>

--- a/examples/position_tcp/position_server.cpp
+++ b/examples/position_tcp/position_server.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <cstdlib>
 #include <iostream>
 #include <list>

--- a/examples/position_udp/position_broadcaster.cpp
+++ b/examples/position_udp/position_broadcaster.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <cstdlib>
 #include <iostream>
 #include <thread>

--- a/examples/position_udp/position_listener.cpp
+++ b/examples/position_udp/position_listener.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <iostream>
 #include <thread>
 

--- a/include/musen/address.hpp
+++ b/include/musen/address.hpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include <arpa/inet.h>

--- a/include/musen/musen.hpp
+++ b/include/musen/musen.hpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include "musen/tcp/client.hpp"

--- a/include/musen/receiver.hpp
+++ b/include/musen/receiver.hpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include <optional>

--- a/include/musen/receiver.tpp
+++ b/include/musen/receiver.tpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include <utility>

--- a/include/musen/sender.hpp
+++ b/include/musen/sender.hpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include <string>

--- a/include/musen/sender.tpp
+++ b/include/musen/sender.tpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include "musen/sender.hpp"

--- a/include/musen/socket.hpp
+++ b/include/musen/socket.hpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include <memory>

--- a/include/musen/socket.tpp
+++ b/include/musen/socket.tpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include <sys/socket.h>

--- a/include/musen/tcp/client.hpp
+++ b/include/musen/tcp/client.hpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include <memory>

--- a/include/musen/tcp/server.hpp
+++ b/include/musen/tcp/server.hpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include <memory>

--- a/include/musen/tcp/session.hpp
+++ b/include/musen/tcp/session.hpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include <memory>

--- a/include/musen/udp/broadcaster.hpp
+++ b/include/musen/udp/broadcaster.hpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include <list>

--- a/include/musen/udp/listener.hpp
+++ b/include/musen/udp/listener.hpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include <memory>

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <ifaddrs.h>
 
 #include <cstring>

--- a/src/receiver.cpp
+++ b/src/receiver.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <string>
 #include <vector>
 

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <string>
 #include <vector>
 

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <fcntl.h>
 #include <unistd.h>
 

--- a/src/tcp/client.cpp
+++ b/src/tcp/client.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <fcntl.h>
 
 #include <memory>

--- a/src/tcp/server.cpp
+++ b/src/tcp/server.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <fcntl.h>
 
 #include <memory>

--- a/src/tcp/session.cpp
+++ b/src/tcp/session.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <memory>
 
 #include "musen/tcp/session.hpp"

--- a/src/udp/broadcaster.cpp
+++ b/src/udp/broadcaster.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <limits>
 #include <list>
 #include <memory>

--- a/src/udp/listener.cpp
+++ b/src/udp/listener.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <memory>
 
 #include "musen/udp/listener.hpp"

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -1,9 +1,3 @@
-# Copyright (c) 2021-2024 ICHIRO ITS
-#
-# Use of this source code is governed by an MIT-style
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/MIT.
-
 find_package(GTest REQUIRED)
 find_package(Threads REQUIRED)
 

--- a/test/gtest/src/address_test.cpp
+++ b/test/gtest/src/address_test.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include "gtest/gtest.h"
 #include "musen/musen.hpp"
 

--- a/test/gtest/src/broadcast_and_listen_test.cpp
+++ b/test/gtest/src/broadcast_and_listen_test.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <cstdlib>
 #include <memory>
 #include <string>

--- a/test/gtest/src/send_and_receive/mocks/mock_receiver.cpp
+++ b/test/gtest/src/send_and_receive/mocks/mock_receiver.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <algorithm>
 
 #include "./mock_receiver.hpp"

--- a/test/gtest/src/send_and_receive/mocks/mock_receiver.hpp
+++ b/test/gtest/src/send_and_receive/mocks/mock_receiver.hpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include <memory>

--- a/test/gtest/src/send_and_receive/mocks/mock_sender.cpp
+++ b/test/gtest/src/send_and_receive/mocks/mock_sender.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include "./mock_sender.hpp"
 
 namespace musen_test {

--- a/test/gtest/src/send_and_receive/mocks/mock_sender.hpp
+++ b/test/gtest/src/send_and_receive/mocks/mock_sender.hpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #pragma once
 
 #include <memory>

--- a/test/gtest/src/send_and_receive/raw_test.cpp
+++ b/test/gtest/src/send_and_receive/raw_test.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <memory>
 
 #include "gtest/gtest.h"

--- a/test/gtest/src/send_and_receive/string_test.cpp
+++ b/test/gtest/src/send_and_receive/string_test.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <memory>
 #include <string>
 

--- a/test/gtest/src/send_and_receive/strings_test.cpp
+++ b/test/gtest/src/send_and_receive/strings_test.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <memory>
 #include <string>
 #include <vector>

--- a/test/gtest/src/send_and_receive/struct_test.cpp
+++ b/test/gtest/src/send_and_receive/struct_test.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <memory>
 
 #include "gtest/gtest.h"

--- a/test/gtest/src/server_and_client_test.cpp
+++ b/test/gtest/src/server_and_client_test.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <cstdlib>
 #include <list>
 #include <memory>

--- a/test/gtest/src/socket/connection_test.cpp
+++ b/test/gtest/src/socket/connection_test.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include "gtest/gtest.h"
 #include "musen/musen.hpp"
 

--- a/test/gtest/src/socket/creation_test.cpp
+++ b/test/gtest/src/socket/creation_test.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <fcntl.h>
 
 #include "gtest/gtest.h"

--- a/test/gtest/src/socket/manipulation_test.cpp
+++ b/test/gtest/src/socket/manipulation_test.cpp
@@ -1,9 +1,3 @@
-// Copyright (c) 2021-2024 ICHIRO ITS
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/MIT.
-
 #include <fcntl.h>
 
 #include <memory>


### PR DESCRIPTION
This pull request resolves #61 by removing the license header in all files.