### PR TITLE
Remove `doc` Target

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -18,29 +18,19 @@ jobs:
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v4.1.7
-        with:
-          path: musen
 
       - name: Install documentation dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y doxygen
 
-      - name: Create a build directory
-        run: mkdir build
-
-      - name: Configure CMake
-        working-directory: build
-        run: cmake ../musen
-
       - name: Build documentation
-        working-directory: build
-        run: make doc
+        run: doxygen
 
       - name: Upload Documentation
         uses: actions/upload-pages-artifact@v3.0.1
         with:
-          path: musen/doc
+          path: doc
 
       - name: Deploy Pages
         id: deploy-pages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,6 @@ install(TARGETS ${PROJECT_NAME}
 
 add_subdirectory("examples")
 
-include("cmake/doc.cmake")
-
 if(BUILD_TESTING)
   enable_testing()
   add_subdirectory("test/gtest")

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ See [releases](https://github.com/ichiro-its/musen/releases) for the latest vers
   $ cmake .. && make
   ```
   > Optionally, you could speed up the build process by specifying the parallel job using `-j` option, see [this](https://www.gnu.org/software/make/manual/html_node/Parallel.html).
-- (Optional) generate documentation using the configured CMake.
+- (Optional) generate documentation.
   ```sh
-  $ make doc
+  $ doxygen
   ```
 - (Optional) reconfigure CMake to build a Debian packages.
   ```sh

--- a/cmake/doc.cmake
+++ b/cmake/doc.cmake
@@ -1,3 +1,0 @@
-add_custom_target(doc
-  COMMAND doxygen
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
This pull request resolves #65 by removing the `doc` target from this project and modifying the `deploy-documentation` job to call the `doxygen` command directly for building the documentation.