### PR TITLE
[Bugfix] solve error on broadcast message after disconnecting from wifi

### DIFF
--- a/src/udp/broadcaster.cpp
+++ b/src/udp/broadcaster.cpp
@@ -21,6 +21,7 @@ Broadcaster::~Broadcaster() {
 
 size_t Broadcaster::send_raw(const char * data, const size_t & length) {
   // Obtain all addresses
+  this->enable_broadcast(true);
   auto addresses = broadcast_addresses;
   for (const auto & ip : target_ips) {
     addresses.push_back(Address(ip, port));


### PR DESCRIPTION
## Jira Link: 

## Description

recall `enable_broadcast` before sending a message on `send_raw` at broadcaster.cpp
## Type of Change

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [x] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.