### PR TITLE
Add CMake Options

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build project
         uses: threeal/cmake-action@v1.3.0
         with:
-          options: MUSEN_BUILD_TESTS=ON
+          options: MUSEN_BUILD_TESTS=ON MUSEN_BUILD_EXAMPLES=ON
           run-build: true
 
       - name: Test project

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build project
         uses: threeal/cmake-action@v1.3.0
         with:
-          options: BUILD_TESTING=ON
+          options: MUSEN_BUILD_TESTS=ON
           run-build: true
 
       - name: Test project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.5)
 
 project(musen)
 
+option(MUSEN_BUILD_TESTS "Build test targets.")
+
 function(cpmaddpackage)
   file(
     DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.40.1/CPM.cmake
@@ -42,7 +44,7 @@ install(TARGETS ${PROJECT_NAME}
 
 add_subdirectory("examples")
 
-if(BUILD_TESTING)
+if(MUSEN_BUILD_TESTS)
   enable_testing()
   add_subdirectory("test/gtest")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,10 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.21)
 
 project(musen)
 
 option(MUSEN_BUILD_TESTS "Build test targets.")
 option(MUSEN_BUILD_EXAMPLES "Build example targets.")
+option(MUSEN_ENABLE_INSTALL "Enable targets installation." "${PROJECT_IS_TOP_LEVEL}")
 
 function(cpmaddpackage)
   file(
@@ -18,9 +19,6 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 17)
 
 add_compile_options(-Wall -Wextra -Wpedantic -fPIC)
-
-install(DIRECTORY "include/musen"
-  DESTINATION "include")
 
 add_library(${PROJECT_NAME} SHARED
   "src/tcp/client.cpp"
@@ -37,12 +35,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
 
-install(TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}_export
-  ARCHIVE DESTINATION "lib"
-  LIBRARY DESTINATION "lib"
-  RUNTIME DESTINATION "bin")
-
 if(MUSEN_BUILD_TESTS)
   enable_testing()
   add_subdirectory("test/gtest")
@@ -52,7 +44,18 @@ if(MUSEN_BUILD_EXAMPLES)
   add_subdirectory("examples")
 endif()
 
-install(EXPORT ${PROJECT_NAME}_export
-  FILE ${PROJECT_NAME}-config.cmake
-  NAMESPACE ${PROJECT_NAME}::
-  DESTINATION "lib/cmake/${PROJECT_NAME}")
+if(MUSEN_ENABLE_INSTALL)
+  install(DIRECTORY "include/musen"
+    DESTINATION "include")
+
+  install(TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}_export
+    ARCHIVE DESTINATION "lib"
+    LIBRARY DESTINATION "lib"
+    RUNTIME DESTINATION "bin")
+
+  install(EXPORT ${PROJECT_NAME}_export
+    FILE ${PROJECT_NAME}-config.cmake
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION "lib/cmake/${PROJECT_NAME}")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 project(musen)
 
 option(MUSEN_BUILD_TESTS "Build test targets.")
+option(MUSEN_BUILD_EXAMPLES "Build example targets.")
 
 function(cpmaddpackage)
   file(
@@ -42,11 +43,13 @@ install(TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION "lib"
   RUNTIME DESTINATION "bin")
 
-add_subdirectory("examples")
-
 if(MUSEN_BUILD_TESTS)
   enable_testing()
   add_subdirectory("test/gtest")
+endif()
+
+if(MUSEN_BUILD_EXAMPLES)
+  add_subdirectory("examples")
 endif()
 
 install(EXPORT ${PROJECT_NAME}_export

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See [releases](https://github.com/ichiro-its/musen/releases) for the latest vers
   ```
 - (Optional) reconfigure CMake to run the unit tests.
   ```sh
-  $ cmake -DBUILD_TESTING=ON .. && make && ctest --verbose
+  $ cmake -DMUSEN_BUILD_TESTS=ON .. && make && ctest --verbose
   ```
 
 ## Usages

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,6 +14,7 @@ foreach(EXAMPLE ${EXAMPLES})
   add_executable(${TARGET} "${EXAMPLE}")
   target_link_libraries(${TARGET} ${PROJECT_NAME})
 
-  install(TARGETS ${TARGET}
-    DESTINATION "bin")
+  if(MUSEN_ENABLE_INSTALL)
+    install(TARGETS ${TARGET} DESTINATION "bin")
+  endif()
 endforeach()


### PR DESCRIPTION
This pull request resolves #73 by introducing the following CMake options:
- `MUSEN_BUILD_TESTS` for building test targets, disabled by default, replacing the `BUILD_TESTING` option.
- `MUSEN_BUILD_EXAMPLES` for building example targets, disabled by default.
- `MUSEN_ENABLE_INSTALL` for enabling target installation, enabled by default if it is not a subproject.

It also bumps the minimum CMake version to 3.21 because of the introduction of the [`PROJECT_IS_TOP_LEVEL`](https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html) variable.