### PR TITLE
Utilize CMake and CTest Actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,6 +23,5 @@ jobs:
           options: BUILD_TESTING=ON
           run-build: true
 
-      - name: Test the project
-        working-directory: build
-        run: ctest --verbose
+      - name: Test project
+        uses: threeal/ctest-action@v1.1.0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,24 +11,17 @@ jobs:
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v4.1.7
-        with:
-          path: musen
 
       - name: Install test dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtest-dev
 
-      - name: Create a build directory
-        run: mkdir build
-
-      - name: Configure CMake
-        working-directory: build
-        run: cmake -DBUILD_TESTING=ON ../musen
-
-      - name: Build the project
-        working-directory: build
-        run: make -j8
+      - name: Build project
+        uses: threeal/cmake-action@v1.3.0
+        with:
+          options: BUILD_TESTING=ON
+          run-build: true
 
       - name: Test the project
         working-directory: build


### PR DESCRIPTION
This pull request resolves #75 by updating the `build-and-test.yaml` workflow to utilize the [CMake Action](https://github.com/marketplace/actions/cmake-action) for building the project and the [CTest Action](https://github.com/marketplace/actions/ctest-action) for testing the project.