### PR TITLE
Use CPM.cmake to Get Missing Dependencies

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,11 +12,6 @@ jobs:
       - name: Checkout this repository
         uses: actions/checkout@v4.1.7
 
-      - name: Install test dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtest-dev
-
       - name: Build project
         uses: threeal/cmake-action@v1.3.0
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,15 @@ cmake_minimum_required(VERSION 3.5)
 
 project(musen)
 
+function(cpmaddpackage)
+  file(
+    DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.40.1/CPM.cmake
+    ${CMAKE_BINARY_DIR}/_deps/CPM.cmake
+    EXPECTED_MD5 a5467d77aa63a1197ea4e1644623acb7)
+  include(${CMAKE_BINARY_DIR}/_deps/CPM.cmake)
+  cpmaddpackage(${ARGN})
+endfunction()
+
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 17)
 

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -1,4 +1,8 @@
-find_package(GTest REQUIRED)
+find_package(GTest QUIET)
+if(NOT GTest_FOUND)
+  cpmaddpackage(gh:google/googletest@1.15.0)
+endif()
+
 find_package(Threads REQUIRED)
 
 add_executable(${PROJECT_NAME}_tests


### PR DESCRIPTION
This pull request resolves #77 by utilizing [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) to get missing packages, particularly [Google Test](https://google.github.io/googletest/) if it's not found on the system. This change also removes the step for installing Google Test in the `build-and-test.yml` workflow.