### PR TITLE
Avoid Passing Primitive Types as References

### DIFF
--- a/include/musen/address.hpp
+++ b/include/musen/address.hpp
@@ -9,12 +9,12 @@ namespace musen {
 
 struct Address;
 
-Address make_any_address(const int & port);
+Address make_any_address(int port);
 
 std::list<std::string> obtain_broadcast_ips();
 
 struct Address {
-  Address(const std::string & ip, const int & port);
+  Address(const std::string & ip, int port);
   explicit Address(const sockaddr_in & sa);
   Address();
 

--- a/include/musen/receiver.hpp
+++ b/include/musen/receiver.hpp
@@ -8,10 +8,10 @@ namespace musen {
 
 class Receiver {
  public:
-  virtual size_t receive_raw(char * data, const size_t & length);
+  virtual size_t receive_raw(char * data, size_t length);
 
-  std::string receive_string(const size_t & length);
-  std::vector<std::string> receive_strings(const size_t & length, const std::string & delimiter = ",");
+  std::string receive_string(size_t length);
+  std::vector<std::string> receive_strings(size_t length, const std::string & delimiter = ",");
 
   template<typename T>
   std::optional<T> receive();

--- a/include/musen/sender.hpp
+++ b/include/musen/sender.hpp
@@ -7,7 +7,7 @@ namespace musen {
 
 class Sender {
  public:
-  virtual size_t send_raw(const char * data, const size_t & length);
+  virtual size_t send_raw(const char * data, size_t length);
 
   size_t send_string(const std::string & data);
   size_t send_strings(const std::vector<std::string> & data, const std::string & delimiter = ",");

--- a/include/musen/socket.hpp
+++ b/include/musen/socket.hpp
@@ -16,35 +16,35 @@ std::shared_ptr<Socket> make_blocking_udp_socket();
 
 class Socket {
  public:
-  explicit Socket(const int & fd);
-  Socket(const int & domain, const int & type, const int & protocol);
+  explicit Socket(int fd);
+  Socket(int domain, int type, int protocol);
 
   ~Socket();
 
   void bind(const Address & address);
   void connect(const Address & address);
-  void listen(const int & max_queue = 8);
+  void listen(int max_queue = 8);
 
   std::shared_ptr<Socket> accept();
 
-  size_t send(const void * data, const size_t & length);
-  size_t send_to(const void * data, const size_t & length, const Address & address);
+  size_t send(const void * data, size_t length);
+  size_t send_to(const void * data, size_t length, const Address & address);
 
-  size_t receive(void * data, const size_t & length);
+  size_t receive(void * data, size_t length);
 
-  void set_status_flags(const int & flags);
+  void set_status_flags(int flags);
   int get_status_flags() const;
 
-  void set_status_flag(const int & key, const bool & enable);
-  bool get_status_flag(const int & key) const;
+  void set_status_flag(int key, bool enable);
+  bool get_status_flag(int key) const;
 
   template<typename T>
-  void set_option(const int & key, const T & value);
+  void set_option(int key, const T & value);
 
   template<typename T>
-  T get_option(const int & key) const;
+  T get_option(int key) const;
 
-  const int & get_fd() const;
+  int get_fd() const;
 
  private:
   int fd;

--- a/include/musen/socket.tpp
+++ b/include/musen/socket.tpp
@@ -8,14 +8,14 @@
 namespace musen {
 
 template<typename T>
-void Socket::set_option(const int & key, const T & value) {
+void Socket::set_option(int key, const T & value) {
   if (setsockopt(fd, SOL_SOCKET, key, &value, sizeof(value)) == -1) {
     throw std::system_error(errno, std::generic_category());
   }
 }
 
 template<typename T>
-T Socket::get_option(const int & key) const {
+T Socket::get_option(int key) const {
   T value;
   socklen_t value_len = sizeof(value);
 

--- a/include/musen/tcp/client.hpp
+++ b/include/musen/tcp/client.hpp
@@ -16,8 +16,8 @@ class Client : public Sender, public Receiver {
 
   ~Client();
 
-  size_t send_raw(const char * data, const size_t & length) override;
-  size_t receive_raw(char * data, const size_t & length) override;
+  size_t send_raw(const char * data, size_t length) override;
+  size_t receive_raw(char * data, size_t length) override;
 
   std::shared_ptr<Socket> get_socket() const;
   const Address & get_server_address() const;

--- a/include/musen/tcp/server.hpp
+++ b/include/musen/tcp/server.hpp
@@ -10,13 +10,13 @@ namespace musen {
 
 class Server {
  public:
-  explicit Server(const int & port, std::shared_ptr<Socket> socket = make_tcp_socket());
+  explicit Server(int port, std::shared_ptr<Socket> socket = make_tcp_socket());
   ~Server();
 
   std::shared_ptr<Session> accept();
 
   std::shared_ptr<Socket> get_socket() const;
-  const int & get_port() const;
+  int get_port() const;
 
  protected:
   std::shared_ptr<Socket> socket;

--- a/include/musen/tcp/session.hpp
+++ b/include/musen/tcp/session.hpp
@@ -13,8 +13,8 @@ class Session : public Sender, public Receiver {
   explicit Session(std::shared_ptr<Socket> socket);
   ~Session();
 
-  size_t send_raw(const char * data, const size_t & length) override;
-  size_t receive_raw(char * data, const size_t & length) override;
+  size_t send_raw(const char * data, size_t length) override;
+  size_t receive_raw(char * data, size_t length) override;
 
   std::shared_ptr<Socket> get_socket() const;
 

--- a/include/musen/udp/broadcaster.hpp
+++ b/include/musen/udp/broadcaster.hpp
@@ -12,15 +12,15 @@ namespace musen {
 
 class Broadcaster : public Sender {
  public:
-  explicit Broadcaster(const int & port, std::shared_ptr<Socket> socket = make_udp_socket());
+  explicit Broadcaster(int port, std::shared_ptr<Socket> socket = make_udp_socket());
   ~Broadcaster();
 
-  size_t send_raw(const char * data, const size_t & length) override;
+  size_t send_raw(const char * data, size_t length) override;
 
-  void enable_broadcast(const bool & enable);
+  void enable_broadcast(bool enable);
 
   std::shared_ptr<Socket> get_socket() const;
-  const int & get_port() const;
+  int get_port() const;
 
   std::list<std::string> target_ips;
 

--- a/include/musen/udp/listener.hpp
+++ b/include/musen/udp/listener.hpp
@@ -9,13 +9,13 @@ namespace musen {
 
 class Listener : public Receiver {
  public:
-  explicit Listener(const int & port, std::shared_ptr<Socket> socket = make_udp_socket());
+  explicit Listener(int port, std::shared_ptr<Socket> socket = make_udp_socket());
   ~Listener();
 
-  size_t receive_raw(char * data, const size_t & length) override;
+  size_t receive_raw(char * data, size_t length) override;
 
   std::shared_ptr<Socket> get_socket() const;
-  const int & get_port() const;
+  int get_port() const;
 
  protected:
   std::shared_ptr<Socket> socket;

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -9,7 +9,7 @@
 
 namespace musen {
 
-Address make_any_address(const int & port) {
+Address make_any_address(int port) {
   return Address("0.0.0.0", port);
 }
 
@@ -40,7 +40,7 @@ std::list<std::string> obtain_broadcast_ips() {
   return ips;
 }
 
-Address::Address(const std::string & ip, const int & port) {
+Address::Address(const std::string & ip, int port) {
   this->ip = ip;
   this->port = port;
 }

--- a/src/receiver.cpp
+++ b/src/receiver.cpp
@@ -5,11 +5,11 @@
 
 namespace musen {
 
-size_t Receiver::receive_raw(char * /*data*/, const size_t & /*length*/) {
+size_t Receiver::receive_raw(char * /*data*/, size_t /*length*/) {
   return 0;
 }
 
-std::string Receiver::receive_string(const size_t & length) {
+std::string Receiver::receive_string(size_t length) {
   std::string data;
   if (length <= 0) {
     return data;
@@ -31,7 +31,7 @@ std::string Receiver::receive_string(const size_t & length) {
   return data;
 }
 
-std::vector<std::string> Receiver::receive_strings(const size_t & length, const std::string & delimiter) {
+std::vector<std::string> Receiver::receive_strings(size_t length, const std::string & delimiter) {
   auto data = receive_string(length);
 
   std::vector<std::string> splitted_data;

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -5,7 +5,7 @@
 
 namespace musen {
 
-size_t Sender::send_raw(const char * /*data*/, const size_t & /*length*/) {
+size_t Sender::send_raw(const char * /*data*/, size_t /*length*/) {
   return 0;
 }
 

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<Socket> make_blocking_udp_socket() {
   return std::make_shared<Socket>(AF_INET, SOCK_DGRAM, IPPROTO_IP);
 }
 
-Socket::Socket(const int & fd) {
+Socket::Socket(int fd) {
   this->fd = fd;
 
   if (get_option<int>(SO_ERROR) != 0) {
@@ -37,7 +37,7 @@ Socket::Socket(const int & fd) {
   }
 }
 
-Socket::Socket(const int & domain, const int & type, const int & protocol) {
+Socket::Socket(int domain, int type, int protocol) {
   fd = socket(domain, type, protocol);
   if (fd == -1) {
     throw std::system_error(errno, std::generic_category());
@@ -62,7 +62,7 @@ void Socket::connect(const Address & address) {
   }
 }
 
-void Socket::listen(const int & max_queue) {
+void Socket::listen(int max_queue) {
   if (socket_listen(fd, max_queue) == -1) {
     throw std::system_error(errno, std::generic_category());
   }
@@ -80,7 +80,7 @@ std::shared_ptr<Socket> Socket::accept() {
   return std::make_shared<Socket>(retval);
 }
 
-size_t Socket::send(const void * data, const size_t & length) {
+size_t Socket::send(const void * data, size_t length) {
   auto retval = socket_send(fd, data, length, MSG_NOSIGNAL);
   if (retval == -1) {
     throw std::system_error(errno, std::generic_category());
@@ -89,7 +89,7 @@ size_t Socket::send(const void * data, const size_t & length) {
   return retval;
 }
 
-size_t Socket::send_to(const void * data, const size_t & length, const Address & address) {
+size_t Socket::send_to(const void * data, size_t length, const Address & address) {
   auto sa = address.sockaddr_in();
   auto retval = sendto(fd, data, length, MSG_NOSIGNAL, (struct sockaddr *)&sa, sizeof(sa));
   if (retval == -1) {
@@ -99,7 +99,7 @@ size_t Socket::send_to(const void * data, const size_t & length, const Address &
   return retval;
 }
 
-size_t Socket::receive(void * data, const size_t & length) {
+size_t Socket::receive(void * data, size_t length) {
   auto retval = recv(fd, data, length, 0);
   if (retval == -1) {
     if (errno == EAGAIN) {
@@ -112,7 +112,7 @@ size_t Socket::receive(void * data, const size_t & length) {
   return retval;
 }
 
-void Socket::set_status_flags(const int & flags) {
+void Socket::set_status_flags(int flags) {
   if (fcntl(fd, F_SETFL, flags) == -1) {
     throw std::system_error(errno, std::generic_category());
   }
@@ -127,16 +127,16 @@ int Socket::get_status_flags() const {
   return flags;
 }
 
-void Socket::set_status_flag(const int & key, const bool & enable) {
+void Socket::set_status_flag(int key, bool enable) {
   auto flags = get_status_flags();
   set_status_flags(enable ? (flags | key) : (flags & ~key));
 }
 
-bool Socket::get_status_flag(const int & key) const {
+bool Socket::get_status_flag(int key) const {
   return get_status_flags() & key;
 }
 
-const int & Socket::get_fd() const {
+int Socket::get_fd() const {
   return fd;
 }
 

--- a/src/tcp/client.cpp
+++ b/src/tcp/client.cpp
@@ -28,11 +28,11 @@ Client::~Client() {
   socket = nullptr;
 }
 
-size_t Client::send_raw(const char * data, const size_t & length) {
+size_t Client::send_raw(const char * data, size_t length) {
   return socket->send(data, length);
 }
 
-size_t Client::receive_raw(char * data, const size_t & length) {
+size_t Client::receive_raw(char * data, size_t length) {
   return socket->receive(data, length);
 }
 

--- a/src/tcp/server.cpp
+++ b/src/tcp/server.cpp
@@ -6,7 +6,7 @@
 
 namespace musen {
 
-Server::Server(const int & port, std::shared_ptr<Socket> socket) {
+Server::Server(int port, std::shared_ptr<Socket> socket) {
   this->socket = socket;
   this->port = port;
 
@@ -44,7 +44,7 @@ std::shared_ptr<Socket> Server::get_socket() const {
   return socket;
 }
 
-const int & Server::get_port() const {
+int Server::get_port() const {
   return port;
 }
 

--- a/src/tcp/session.cpp
+++ b/src/tcp/session.cpp
@@ -12,11 +12,11 @@ Session::~Session() {
   socket = nullptr;
 }
 
-size_t Session::send_raw(const char * data, const size_t & length) {
+size_t Session::send_raw(const char * data, size_t length) {
   return socket->send(data, length);
 }
 
-size_t Session::receive_raw(char * data, const size_t & length) {
+size_t Session::receive_raw(char * data, size_t length) {
   try {
     return socket->receive(data, length);
   } catch (const std::system_error & err) {

--- a/src/udp/broadcaster.cpp
+++ b/src/udp/broadcaster.cpp
@@ -8,7 +8,7 @@
 
 namespace musen {
 
-Broadcaster::Broadcaster(const int & port, std::shared_ptr<Socket> socket) {
+Broadcaster::Broadcaster(int port, std::shared_ptr<Socket> socket) {
   this->socket = socket;
   this->port = port;
 
@@ -19,7 +19,7 @@ Broadcaster::~Broadcaster() {
   socket = nullptr;
 }
 
-size_t Broadcaster::send_raw(const char * data, const size_t & length) {
+size_t Broadcaster::send_raw(const char * data, size_t length) {
   // Obtain all addresses
   this->enable_broadcast(true);
   auto addresses = broadcast_addresses;
@@ -41,7 +41,7 @@ size_t Broadcaster::send_raw(const char * data, const size_t & length) {
   return lowest_sent.value_or(0);
 }
 
-void Broadcaster::enable_broadcast(const bool & enable) {
+void Broadcaster::enable_broadcast(bool enable) {
   socket->set_option<int>(SO_BROADCAST, enable);
 
   broadcast_addresses.clear();
@@ -56,7 +56,7 @@ std::shared_ptr<Socket> Broadcaster::get_socket() const {
   return socket;
 }
 
-const int & Broadcaster::get_port() const {
+int Broadcaster::get_port() const {
   return port;
 }
 

--- a/src/udp/listener.cpp
+++ b/src/udp/listener.cpp
@@ -4,7 +4,7 @@
 
 namespace musen {
 
-Listener::Listener(const int & port, std::shared_ptr<Socket> socket) {
+Listener::Listener(int port, std::shared_ptr<Socket> socket) {
   this->socket = socket;
   this->port = port;
 
@@ -19,7 +19,7 @@ Listener::~Listener() {
   socket = nullptr;
 }
 
-size_t Listener::receive_raw(char * data, const size_t & length) {
+size_t Listener::receive_raw(char * data, size_t length) {
   return socket->receive(data, length);
 }
 
@@ -27,7 +27,7 @@ std::shared_ptr<Socket> Listener::get_socket() const {
   return socket;
 }
 
-const int & Listener::get_port() const {
+int Listener::get_port() const {
   return port;
 }
 

--- a/test/gtest/src/send_and_receive/mocks/mock_receiver.cpp
+++ b/test/gtest/src/send_and_receive/mocks/mock_receiver.cpp
@@ -8,7 +8,7 @@ MockReceiver::MockReceiver(std::shared_ptr<Buffers> buffers) {
   this->buffers = buffers;
 }
 
-size_t MockReceiver::receive_raw(char * data, const size_t & length) {
+size_t MockReceiver::receive_raw(char * data, size_t length) {
   if (buffers->empty()) {
     return 0;
   }

--- a/test/gtest/src/send_and_receive/mocks/mock_receiver.hpp
+++ b/test/gtest/src/send_and_receive/mocks/mock_receiver.hpp
@@ -14,7 +14,7 @@ class MockReceiver : public musen::Receiver {
  public:
   explicit MockReceiver(std::shared_ptr<Buffers> buffers);
 
-  size_t receive_raw(char * data, const size_t & length) override;
+  size_t receive_raw(char * data, size_t length) override;
 
  private:
   std::shared_ptr<Buffers> buffers;

--- a/test/gtest/src/send_and_receive/mocks/mock_sender.cpp
+++ b/test/gtest/src/send_and_receive/mocks/mock_sender.cpp
@@ -6,7 +6,7 @@ MockSender::MockSender(std::shared_ptr<Buffers> buffers) {
   this->buffers = buffers;
 }
 
-size_t MockSender::send_raw(const char * data, const size_t & length) {
+size_t MockSender::send_raw(const char * data, size_t length) {
   std::vector buffer(data, data + length);
   buffers->push(buffer);
 

--- a/test/gtest/src/send_and_receive/mocks/mock_sender.hpp
+++ b/test/gtest/src/send_and_receive/mocks/mock_sender.hpp
@@ -14,7 +14,7 @@ class MockSender : public musen::Sender {
  public:
   explicit MockSender(std::shared_ptr<Buffers> buffers);
 
-  size_t send_raw(const char * data, const size_t & length) override;
+  size_t send_raw(const char * data, size_t length) override;
 
  private:
   std::shared_ptr<Buffers> buffers;


### PR DESCRIPTION
This pull request resolves #79 by modifying functions in this project to avoid passing and returning primitive types as references.